### PR TITLE
Gradle Plugin: Allow using Gradle configuration cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,10 +19,18 @@ on:
     branches: [ main ]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.head_commit.id }}-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: true
+
 jobs:
   java:
-    name: Java/Gradle
+    name: CI Java/Gradle
     runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 3
+      matrix:
+        java-version: ['11', '17', '19']
     steps:
       - uses: actions/checkout@v3
         with:
@@ -32,10 +40,12 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: ${{ matrix.java-version }}
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
+        env:
+          GRADLE_BUILD_ACTION_CACHE_KEY_ENVIRONMENT: java-${{ matrix.java-version }}
         with:
           arguments: build publishToMavenLocal --scan
 
@@ -47,3 +57,15 @@ jobs:
           path: |
             **/build/reports/*
             **/build/test-results/*
+
+  finish:
+    # 'Ci Success' is the (only) required check for PRs, so we can change the jobs above without
+    # having to update the GH configuration every time.
+    name: CI Success
+    runs-on: ubuntu-22.04
+    needs:
+      - java
+    steps:
+      # Intentionally empty job (for all GH WF) events so that the "required checks" setting
+      # only needs to contain this job as the only required check for PRs.
+      - run: echo "Success"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Twitter](https://img.shields.io/badge/Twitter-Follow_Us-blue?color=3d4db3&logo=twitter&style=for-the-badge&logoColor=white)](https://twitter.com/projectnessie)
 [![Website](https://img.shields.io/badge/https-projectnessie.org-blue?color=3d4db3&logo=firefox&style=for-the-badge&logoColor=white)](https://projectnessie.org/)
 
-[![Build Status](https://img.shields.io/github/actions/workflow/status/projectnessie/annotation-stripper/main.yml?label=Main%20CI&logo=Github&style=for-the-badge)](https://github.com/projectnessie/annotation-stripper/actions/workflows/main.yml)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/projectnessie/annotation-stripper/main.yml?label=Main%20CI&logo=Github&style=for-the-badge)](https://github.com/projectnessie/annotation-stripper/actions/workflows/main.yml?query=branch%3Amain)
 [![Maven Central](https://img.shields.io/maven-central/v/org.projectnessie.annotation-stripper/annotation-stripper?label=Maven%20Central&logo=apachemaven&color=3f6ec6&style=for-the-badge&logoColor=white)](https://search.maven.org/artifact/org.projectnessie.annotation-stripper/annotation-stripper)
 
 Core classes and Gradle plugin to strip requested annotations from compiled classes.

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -56,6 +56,23 @@ kotlin { jvmToolchain(11) }
 
 tasks.named("pluginUnderTestMetadata") { dependsOn(tasks.named("processJandexIndex")) }
 
+tasks.withType(Test::class.java).configureEach {
+  jvmArgs(
+    "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+    "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
+    "--add-opens=java.base/java.util=ALL-UNNAMED"
+  )
+}
+
 publishing {
   publications {
     withType(MavenPublication::class.java).configureEach {

--- a/plugin/src/test/kotlin/org/projectnessie/annotationstripper/plugin/TestAnnotationStripper.kt
+++ b/plugin/src/test/kotlin/org/projectnessie/annotationstripper/plugin/TestAnnotationStripper.kt
@@ -43,7 +43,11 @@ class TestAnnotationStripper {
   fun checkPlugin() {
     copyProject(TestAnnotationStripper::class.java.classLoader.getResource("test-cases/jakarta")!!)
 
-    createRunner("jar").build()
+    try {
+      createRunner("jar").build()
+    } catch (e: Exception) {
+      throw e
+    }
 
     val buildDir = projectDir!!.resolve("build")
     val strippedClasses = buildDir.resolve("classes/annotationStripped/main")
@@ -78,7 +82,7 @@ class TestAnnotationStripper {
     GradleRunner.create()
       .withPluginClasspath()
       .withProjectDir(projectDir!!.toFile())
-      .withArguments("--build-cache", "--info", "--stacktrace", task)
+      .withArguments("--configuration-cache", "--build-cache", "--info", "--stacktrace", task)
       .withDebug(true)
       .forwardOutput()
 


### PR DESCRIPTION
Also adds Java-Matrix CI for 11, 17, 19

Gradle's configuration cache aims to avoid costly operations that happen during Gradle's configuration phase, which can be comparabily expensive.
    
However, using the configuration cache adds some constraints on everything (plugins, custom tasks, build scripts) used in a Gradle build. For example, capturing some types (e.g. `Configuration`, `DependencySet`) is not possible, need to narrow to "more precise" types (like `FileCollection`).
