### PR TITLE
Update GH workflows / Gradle run steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,12 +42,15 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
 
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
         env:
           GRADLE_BUILD_ACTION_CACHE_KEY_ENVIRONMENT: java-${{ matrix.java-version }}
         with:
-          arguments: build publishToMavenLocal --scan
+          cache-read-only: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
+
+      - name: Build with Gradle
+        run: ./gradlew build publishToMavenLocal --scan
 
       - name: Capture test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,16 +83,18 @@ jobs:
           git commit -a -m "[release] v${RELEASE_VERSION}"
           git tag -f ${GIT_TAG}
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-read-only: true
+
       - name: Publish to Sonatype
-        uses: gradle/gradle-build-action@v2
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.OSSRH_ACCESS_ID }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_TOKEN }}
-        with:
-          cache-read-only: true
-          arguments: assemble publishToMavenLocal publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease
+        run: ./gradlew assemble publishToMavenLocal publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease
 
       #- name: Publish to Sonatype
       #  uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
See https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated for details.

Also make the GH cache read-only for everything except pushes to `main`.